### PR TITLE
!Updated daemon path

### DIFF
--- a/run
+++ b/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 sv check NetworkManager >/dev/null || exit 1
-exec /opt/Mullvad\ VPN/resources/mullvad-daemon
+exec /usr/bin/mullvad-daemon -v --disable-stdout-timestamps


### PR DESCRIPTION
The path for the mullvad-daemon has been changed to `/usr/bin/mullvad-daemon`.
The `-v --disable-stdout-timestamps` flag just stops timestamps from being printed to stdout, doesn't affect log files.